### PR TITLE
Fix typos and add test

### DIFF
--- a/detection-service/modules/yolo_detector.py
+++ b/detection-service/modules/yolo_detector.py
@@ -4,7 +4,7 @@ import numpy as np
 from dataclasses import dataclass
 from typing import List, Dict, Optional
 import torch
-# 导入远程推送器
+# 远程推送器代码已删除，保留占位
 try:
     from ultralytics import YOLO
     YOLO_AVAILABLE = True
@@ -44,7 +44,7 @@ class YOLODetector:
         self.distributed_manager = distributed_manager
         self.use_distributed = distributed_manager is not None
         
-        # 远程推送器
+        # 远程推送器占位
         self.remote_pusher = None
 
         if YOLO_AVAILABLE and not self.use_distributed:

--- a/management-service/static/js/configuration.js
+++ b/management-service/static/js/configuration.js
@@ -177,11 +177,11 @@ async function exportConfig() {
     try {
         showLoading(true);
         
-        const [streamsRes, configRes] = await Promise.all([
+        const [streamsRes, configResp] = await Promise.all([
             fetch('/api/streams'),
             Promise.resolve({ frameConfig })
         ]);
-        
+
         const streamsData = await streamsRes.json();
         
         const exportData = {

--- a/stream-service/modules/stream_manager.py
+++ b/stream-service/modules/stream_manager.py
@@ -209,9 +209,9 @@ class StreamManager:
         try:
             # 验证配置
             required_fields = ['name', 'url', 'type']
-            for field in required_fields:
-                if field not in stream_config:
-                    raise ValueError(f"缺少必要字段: {field}")
+            for fld in required_fields:
+                if fld not in stream_config:
+                    raise ValueError(f"缺少必要字段: {fld}")
             
             # 检查并发流数量限制
             active_streams = len([s for s in self.streams.values() 

--- a/tests/test_stream_manager.py
+++ b/tests/test_stream_manager.py
@@ -1,0 +1,22 @@
+import importlib.util
+import os
+import sys
+
+# Provide dummy modules for optional dependencies
+sys.modules.setdefault('cv2', type('cv2', (), {})())
+sys.modules.setdefault('shipin', type('shipin', (), {})())
+
+spec = importlib.util.spec_from_file_location(
+    'stream_manager',
+    os.path.join(os.path.dirname(__file__), '../stream-service/modules/stream_manager.py'),
+)
+stream_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(stream_manager)
+StreamManager = stream_manager.StreamManager
+
+
+def test_risk_level_mapping():
+    manager = StreamManager(max_concurrent_streams=1)
+    stream_id = manager.add_stream({'name': 'cam1', 'url': 'rtsp://example', 'type': 'rtsp', 'risk_level': '高'})
+    stream = manager.get_stream(stream_id)
+    assert stream.risk_level == 'high'


### PR DESCRIPTION
## Summary
- fix variable name typo in config export
- clarify placeholder comments for remote pusher
- avoid name shadowing in stream manager
- add unit test for risk level mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bcf13653883308d8bedf98f3fce9f